### PR TITLE
Add link to roadmap to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,9 @@ Installed Tools
 - PayloadsAllTheThings
 - SecLists
 
+Roadmap
+=======
+https://github.com/fireeye/commando-vm/wiki/Commando-VM-Roadmap
 
 Legal Notice
 ============

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ Installed Tools
 
 Roadmap
 =======
-https://github.com/fireeye/commando-vm/wiki/Commando-VM-Roadmap
+Find the project's roadmap here: https://github.com/fireeye/commando-vm/wiki/Commando-VM-Roadmap
 
 Legal Notice
 ============


### PR DESCRIPTION
I added the link to Commando VM's roadmap (https://github.com/fireeye/commando-vm/wiki/Commando-VM-Roadmap) to the README.