### PR TITLE
Add Python and Netcat VM Packages to Profiles

### DIFF
--- a/Profiles/Default - ARM.xml
+++ b/Profiles/Default - ARM.xml
@@ -118,5 +118,6 @@
     <package name="winscp.vm" />
     <package name="jre8" />
     <package name="unxutils" />
+    <package name="netcat.vm" />
   </packages>
 </config>

--- a/Profiles/Default.xml
+++ b/Profiles/Default.xml
@@ -121,5 +121,6 @@
     <package name="winscp.vm" />
     <package name="jre8" />
     <package name="unxutils" />
+    <package name="netcat.vm" />
   </packages>
 </config>

--- a/Profiles/Developer.xml
+++ b/Profiles/Developer.xml
@@ -77,5 +77,7 @@
     <package name="sublimetext3.app" />
     <package name="unxutils" />
     <package name="ghidra.vm" />
+    <package name="python3.vm" />
+    <package name="netcat.vm" />
   </packages>
 </config>

--- a/Profiles/Full - ARM.xml
+++ b/Profiles/Full - ARM.xml
@@ -135,5 +135,7 @@
     <package name="dbeaver" />
     <package name="hfsexplorer" />
     <package name="unxutils" />
+    <package name="python3.vm" />
+    <package name="netcat.vm" />
   </packages>
 </config>

--- a/Profiles/Full.xml
+++ b/Profiles/Full.xml
@@ -138,5 +138,7 @@
     <package name="dbeaver" />
     <package name="hfsexplorer" />
     <package name="unxutils" />
+    <package name="python3.vm" />
+    <package name="netcat.vm" />
   </packages>
 </config>

--- a/Profiles/Lite.xml
+++ b/Profiles/Lite.xml
@@ -50,5 +50,6 @@
     <package name="git" />
     <package name="bloodhound-custom-queries.vm" />
     <package name="unxutils" />
+    <package name="netcat.vm" />
   </packages>
 </config>

--- a/Profiles/Victim.xml
+++ b/Profiles/Victim.xml
@@ -48,5 +48,6 @@
     <package name="unxutils" />
     <package name="sysinternals.vm" />
     <package name="fiddlerclassic.vm" />
+    <package name="netcat.vm" />
   </packages>
 </config>


### PR DESCRIPTION
# Issues:
- The Developer and Full profiles did not include Python, a critical component for creating, executing, and maintaining various Red Team tools, especially those that are script-based or non-compiled.
- Netcat, a lightweight and versatile tool, was missing from all profiles. It is frequently used for key tasks such as reverse shells, file transfers, port scanning, and service enumeration.

# Resolution:
- Added Python VM packages to the following profile XMLs:
  - Full
  - Full - ARM
  - Developer
- Added the Netcat VM package to all the profile XMLs.